### PR TITLE
Fixed bug for going to recommendations

### DIFF
--- a/app/assets/stylesheets/nav_bar.css.scss
+++ b/app/assets/stylesheets/nav_bar.css.scss
@@ -13,7 +13,7 @@
   border-radius: 0.1em;
 }
 
-.right li .login {
+.right li .right-side {
   font-size: 1em;
   border-radius: 0.3em;
 }

--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -1,6 +1,10 @@
 class RecommendationsController < ApplicationController
 
   def index
-    @recommendations = current_user.recommendations
+    if current_user
+      @recommendations = current_user.recommendations
+    else
+      redirect_to root_path, notice: "You must be logged in to access that page"
+    end
   end
 end

--- a/app/views/shared/_nav_bar.html.erb
+++ b/app/views/shared/_nav_bar.html.erb
@@ -8,13 +8,16 @@
 
   <section class="top-bar-section">
   <ul class="right">
-    <li class="active">
-    <% unless current_user %>
-      <%= link_to "Login with Twitter", auth_twitter_path, class: "login" %>
+    <% if current_user %>
+      <li><%= link_to "My Top Recommendations", recommendations_path %></li>
+      <li class="active">
+        <%= link_to "Sign out", logout_path, method: :delete, class: "right-side" %>
+      </li>
     <% else %>
-      <%= link_to "Sign out", logout_path, method: :delete, class: "login" %>
+      <li class="active">
+        <%= link_to "Login with Twitter", auth_twitter_path, class: "right-side" %>
+      </li>
     <% end %>
-    </li>
   </ul>
   </section>
   </nav>


### PR DESCRIPTION
closes #33

User now has to login before going to recommendations

Made sure to redirect the user to the home page if they go to recommendations without being logged in.

Added a link to “My Top Recommendations” when the
user is logged in
